### PR TITLE
fix(deps): bump Jackson to 2.21.5 (CVE-2026-54512, CVE-2026-54515)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.release>21</maven.compiler.release>
         <exoreaction-slack-notification-library.version>1.0.17</exoreaction-slack-notification-library.version>
-        <jackson.version>2.21.0</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
     <scm>
         <developerConnection>scm:git:ssh://git@github.com/cantara/Whydah-UserAdminWebApp.git</developerConnection>


### PR DESCRIPTION
## Jackson CVE patch

Bumps Jackson to **2.21.5** (LTS) to remediate:
- **CVE-2026-54512** — jackson-databind RCE via PolymorphicTypeValidator bypass
- **CVE-2026-54515** — case-insensitive deserialization re-opens `@JsonIgnore` fields

Fixes exist only on the 2.18.x / 2.21.x (LTS) / 3.1.4 lines — there is **no fixed 2.22.x**, and 2.22.0 is flagged vulnerable — so this moves onto the patched **2.21 LTS** line.

Part of the coordinated Whydah Jackson release train (TypeLib → Java-SDK → Admin-SDK → services); release cut via Jenkins after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)